### PR TITLE
Add config-driven hotkeys

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+    "host": "127.0.0.1",
+    "port": 1234,
+    "model": "qwen3b-30b-a3b",
+    "hotkeys": [
+        {"keys": "ctrl+shift+1", "prompt_file": "prompts/default.txt"},
+        {"keys": "ctrl+shift+2", "prompt_file": "prompts/french.txt"}
+    ]
+}

--- a/prompts/default.txt
+++ b/prompts/default.txt
@@ -1,0 +1,1 @@
+You are a helpful assistant.

--- a/prompts/french.txt
+++ b/prompts/french.txt
@@ -1,0 +1,1 @@
+Always respond in French.


### PR DESCRIPTION
## Summary
- add `config.json` with LM Studio host, model and hotkey definitions
- store system prompts under `prompts/`
- read config in `lm_clipboard_hotkey.py` and register hotkeys dynamically

## Testing
- `python -m py_compile lm_clipboard_hotkey.py`