### PR TITLE
Move usage notes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # LCH
 
-The script `lm_clipboard_hotkey.py` interacts with LM Studio via a keyboard shortcut.
+`lm_clipboard_hotkey.py` interacts with LM Studio via a keyboard shortcut and
+copies the answer back to your clipboard.
+
+## What's new in v1.3
+
+- **System prompt** via `-s/--system-prompt` or `-f/--system-prompt-file`.
+- **Auto-load**: if the model isn't loaded, the script can attempt a JIT warm-up
+  or call `lms load` when available.
+
+## Quick start
+
+```bash
+# Inline system prompt + auto-load (default)
+python lm_clipboard_hotkey.py -s "Always answer in French."
+
+# Specify the loading strategy
+python lm_clipboard_hotkey.py --load-strategy jit        # (default)
+python lm_clipboard_hotkey.py --load-strategy cli        # uses lms.exe
+python lm_clipboard_hotkey.py --load-strategy off        # do nothing
+```
+
+### Dependencies
+
+```
+pip install requests pyperclip keyboard colorama
+# install the CLI: https://lmstudio.ai/docs/cli
+```

--- a/lm_clipboard_hotkey.py
+++ b/lm_clipboard_hotkey.py
@@ -1,30 +1,5 @@
 #!/usr/bin/env python3
-"""
-lm_clipboard_hotkey.py — Interacts with LM Studio through a keyboard shortcut.
-
-What's new in v1.3
-==================
-✔︎ **System prompt** via `-s/--system-prompt` or `-f/--system-prompt-file` (unchanged).
-✔︎ **Auto-load**: if the model isn't loaded, the script can:
-     • attempt a JIT load (warm-up request)
-     • or call `lms load` (CLI) when available.
-
-Quick start
------------
-```bash
-# Inline system prompt + auto-load (default)
-python lm_clipboard_hotkey.py -s "Always answer in French."
-
-# Specify the loading strategy
-python lm_clipboard_hotkey.py --load-strategy jit        # (default)
-python lm_clipboard_hotkey.py --load-strategy cli        # uses lms.exe
-python lm_clipboard_hotkey.py --load-strategy off        # do nothing
-```
-
-Dependencies:
-    pip install requests pyperclip keyboard colorama
-    # and install the CLI: https://lmstudio.ai/docs/cli
-"""
+"""Send clipboard content to LM Studio when a hotkey is pressed."""
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
- document usage and what's new in README
- replace large docstring with a brief summary

## Testing
- `python -m py_compile lm_clipboard_hotkey.py`