### PR TITLE
Fix hotkey newline with suppress

### DIFF
--- a/lm_clipboard_hotkey.py
+++ b/lm_clipboard_hotkey.py
@@ -293,6 +293,7 @@ def main() -> None:
                 args=(sp, args.load_strategy, args.auto_paste, MODEL_NAME, pf),
                 daemon=True,
             ).start(),
+            suppress=True,
         )
 
     debug("LM Studio Hotkey active! (Ctrl+C to quit)\n", color="magenta")


### PR DESCRIPTION
## Summary
- use `suppress=True` when registering hotkeys to prevent key propagation

## Testing
- `python -m py_compile lm_clipboard_hotkey.py`