### PR TITLE
Add auto-copy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This script currently works only on Windows systems.
 - **Timeout**: set `LMSTUDIO_TIMEOUT` to tweak the wait time (default 60s).
 - **Model selection** via `--model-id`.
 - **Auto-paste**: use `--auto-paste` to send Ctrl+V after copying.
+- **Auto-copy**: use `--auto-copy` to copy the selection before sending.
 
 ## Quick start
 
@@ -25,6 +26,7 @@ python lm_clipboard_hotkey.py --load-strategy jit        # (default)
 python lm_clipboard_hotkey.py --load-strategy cli        # uses lms.exe
 python lm_clipboard_hotkey.py --load-strategy off        # do nothing
 python lm_clipboard_hotkey.py --auto-paste              # send Ctrl+V
+python lm_clipboard_hotkey.py --auto-copy               # copy selection
 python lm_clipboard_hotkey.py --model-id MyModel        # override config
 ```
 

--- a/lm_clipboard_hotkey.py
+++ b/lm_clipboard_hotkey.py
@@ -198,9 +198,13 @@ def handle_hotkey(
     system_prompt: str,
     load_strategy: str,
     auto_paste: bool,
+    auto_copy: bool,
     model_id: str,
     prompt_file: str | None = None,
 ) -> None:
+    if auto_copy:
+        keyboard.press_and_release("ctrl+c")
+        time.sleep(0.1)
     prompt = pyperclip.paste()
     if not prompt.strip():
         debug("[INFO] Clipboard empty.", color="yellow")
@@ -238,6 +242,12 @@ def main() -> None:
         "--auto-paste",
         action="store_true",
         help="Paste the answer with Ctrl+V after copying.",
+    )
+
+    parser.add_argument(
+        "--auto-copy",
+        action="store_true",
+        help="Copy the current selection before sending.",
     )
 
     parser.add_argument(
@@ -290,7 +300,7 @@ def main() -> None:
             keys,
             lambda sp=system_prompt, pf=prompt_file: threading.Thread(
                 target=handle_hotkey,
-                args=(sp, args.load_strategy, args.auto_paste, MODEL_NAME, pf),
+                args=(sp, args.load_strategy, args.auto_paste, args.auto_copy, MODEL_NAME, pf),
                 daemon=True,
             ).start(),
             suppress=True,


### PR DESCRIPTION
## Summary
- add `--auto-copy` flag to copy selected text before sending to LM Studio
- document usage in README

## Testing
- `python -m py_compile lm_clipboard_hotkey.py`

------
https://chatgpt.com/codex/tasks/task_e_68484bdba4908329b0268055150146c6