### PR TITLE
Update hotkey copy handling

### DIFF
--- a/lm_clipboard_hotkey.py
+++ b/lm_clipboard_hotkey.py
@@ -203,6 +203,8 @@ def handle_hotkey(
     prompt_file: str | None = None,
 ) -> None:
     if auto_copy:
+        keyboard.release("ctrl")
+        keyboard.release("shift")
         keyboard.press_and_release("ctrl+c")
         time.sleep(0.1)
     prompt = pyperclip.paste()


### PR DESCRIPTION
## Summary
- release `ctrl` and `shift` before copying selection

## Testing
- `python -m py_compile lm_clipboard_hotkey.py`


------
https://chatgpt.com/codex/tasks/task_e_68485006e1c48329b20a12797c852cc1