### PR TITLE
Fix Linux hotkey issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 copies the answer back to your clipboard. Models are loaded on demand using the
 Just‑in‑Time feature introduced in LM Studio 0.3.6.
 
-This script currently works only on Windows systems.
+This script was designed for Windows. On Linux hotkeys rely on the
+`keyboard` package, which needs access to `/dev/uinput` and often root
+privileges. Even with these, hotkey support may be unreliable.
 
 ## What's new 
 

--- a/lm_clipboard_hotkey.py
+++ b/lm_clipboard_hotkey.py
@@ -37,6 +37,16 @@ def release_left_click() -> None:
         ctypes.windll.user32.mouse_event(0x0004, 0, 0, 0, 0)
 
 
+def warn_linux_privileges() -> None:
+    """Warn about Linux hotkey requirements."""
+    if os.name == "nt":
+        return
+    if not Path("/dev/uinput").exists():
+        debug("[WARN] /dev/uinput missing; hotkeys may fail", color="yellow")
+    if hasattr(os, "geteuid") and os.geteuid() != 0:
+        debug("[WARN] Hotkeys may require root privileges on Linux", color="yellow")
+
+
 def ensure_config() -> None:
     """Create CONFIG_FILE from EXAMPLE_FILE if it doesn't exist."""
     if not CONFIG_FILE.exists() and EXAMPLE_FILE.exists():
@@ -268,6 +278,7 @@ def main() -> None:
     args = parser.parse_args()
 
     ensure_config()
+    warn_linux_privileges()
     config = load_config(CONFIG_FILE)
 
     env_host = os.getenv("LM_STUDIO_HOST")


### PR DESCRIPTION
## Summary
- warn when uinput is missing on Linux
- clarify Linux hotkey limitations in README

## Testing
- `python3 -m py_compile lm_clipboard_hotkey.py settings.py`

------
https://chatgpt.com/codex/tasks/task_e_68499386bfc48329b2c5ec749df8b875