### PR TITLE
Add explain hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ privileges. Even with these, hotkey support may be unreliable.
 - **Model selection** via `--model-id`.
 - **Auto-paste**: use `--auto-paste` to send Ctrl+V after copying.
 - **Auto-copy**: use `--auto-copy` to copy the selection before sending.
+- **Explain**: sample hotkey to explain the meaning of the clipboard text.
 
 ## Quick start
 

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,7 @@
         {"keys": "ctrl+shift+1", "prompt_file": "prompts/EN-Grammar.txt"},
         {"keys": "ctrl+shift+2", "prompt_file": "prompts/EN-FR.txt"},
         {"keys": "ctrl+shift+3", "prompt_file": "prompts/FR-Grammar.txt"},
-        {"keys": "ctrl+shift+4", "prompt_file": "prompts/FR-EN.txt"}
+        {"keys": "ctrl+shift+4", "prompt_file": "prompts/FR-EN.txt"},
+        {"keys": "ctrl+shift+5", "prompt_file": "prompts/Explain.txt"}
     ]
 }

--- a/prompts/Explain.txt
+++ b/prompts/Explain.txt
@@ -1,0 +1,1 @@
+Explique le sens du texte suivant en français de façon concise. Fournis uniquement l'explication.


### PR DESCRIPTION
## Summary
- add Explain prompt
- document new hotkey in config and README

## Testing
- `python -m py_compile lm_clipboard_hotkey.py settings.py`

------
https://chatgpt.com/codex/tasks/task_e_684ae47509dc8329801c5a4239324c9b