### PR TITLE
Add run-hotkey flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ privileges. Even with these, hotkey support may be unreliable.
 - **Auto-paste**: use `--auto-paste` to send Ctrl+V after copying.
 - **Auto-copy**: use `--auto-copy` to copy the selection before sending.
 - **Explain**: sample hotkey to explain the meaning of the clipboard text.
+- **Run once**: use `--run-hotkey N` to trigger hotkey `N` then exit.
 
 ## Quick start
 
@@ -31,6 +32,7 @@ python lm_clipboard_hotkey.py --load-strategy off        # do nothing
 python lm_clipboard_hotkey.py --auto-paste              # send Ctrl+V
 python lm_clipboard_hotkey.py --auto-copy               # copy selection
 python lm_clipboard_hotkey.py --model-id MyModel        # override config
+python lm_clipboard_hotkey.py --run-hotkey 1            # run #1 and exit
 ```
 
 ### Dependencies


### PR DESCRIPTION
## Summary
- add `--run-hotkey` to execute a shortcut once then exit
- document new flag in README

## Testing
- `python3 -m py_compile lm_clipboard_hotkey.py`

------
https://chatgpt.com/codex/tasks/task_e_684bb00e591083299def8967d0e4415f