### PR TITLE
feat: adapt paste keys by OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ privileges. Even with these, hotkey support may be unreliable.
 - **Auto-load**: missing models are loaded automatically on the first request.
 - **Timeout**: set `LMSTUDIO_TIMEOUT` to tweak the wait time (default 60s).
 - **Model selection** via `--model-id`.
-- **Auto-paste**: use `--auto-paste` to send Ctrl+V after copying.
+- **Auto-paste**: use `--auto-paste` to paste with OS defaults (override with `--paste-keys`).
 - **Auto-copy**: use `--auto-copy` to copy the selection before sending.
 - **Explain**: sample hotkey to explain the meaning of the clipboard text.
 - **Run once**: use `--run-hotkey N` to trigger hotkey `N` then exit.
@@ -29,7 +29,8 @@ python lm_clipboard_hotkey.py -s "Always answer in French."
 python lm_clipboard_hotkey.py --load-strategy jit        # (default)
 python lm_clipboard_hotkey.py --load-strategy cli        # uses lms.exe
 python lm_clipboard_hotkey.py --load-strategy off        # do nothing
-python lm_clipboard_hotkey.py --auto-paste              # send Ctrl+V
+python lm_clipboard_hotkey.py --auto-paste              # paste using OS default
+python lm_clipboard_hotkey.py --paste-keys "ctrl+shift+v" # custom combo
 python lm_clipboard_hotkey.py --auto-copy               # copy selection
 python lm_clipboard_hotkey.py --model-id MyModel        # override config
 python lm_clipboard_hotkey.py --run-hotkey 1            # run #1 and exit


### PR DESCRIPTION
## Summary
- default paste keys now adjust based on the operating system
- update help text and README for auto-paste

## Testing
- `python -m py_compile lm_clipboard_hotkey.py`


------
https://chatgpt.com/codex/tasks/task_e_684bf6cbba5c83299ca68d3b17812b11