### PR TITLE
Add per-hotkey model option

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -8,6 +8,6 @@
         {"keys": "ctrl+shift+3", "prompt_file": "prompts/FR-Grammar.txt"},
         {"keys": "ctrl+shift+4", "prompt_file": "prompts/FR-EN.txt"},
         {"keys": "ctrl+shift+5", "prompt_file": "prompts/Explain.txt"},
-        {"keys": "ctrl+shift+6"}
+        {"keys": "ctrl+shift+6", "model": "qwen3-30b-a3b"}
     ]
 }


### PR DESCRIPTION
## Summary
- allow hotkeys to specify a custom model
- set qwen3-30b-a3b for `ctrl+shift+6` example

## Testing
- `python -m py_compile lm_clipboard_hotkey.py`


------
https://chatgpt.com/codex/tasks/task_e_6852c245717c83299d728ddfc794f7c2